### PR TITLE
version tests

### DIFF
--- a/template/utils/version.py
+++ b/template/utils/version.py
@@ -21,7 +21,9 @@ class LocalMetadata:
     @staticmethod
     def local_metadata() -> "LocalMetadata":
         """Extract the version as current git commit hash"""
-        commit_hash = ""
+        commit_hash = "head error"
+        remote_commit_hash = "remote head error"
+        bittensor_version = "metadata exception"
         try:
             bittensor_version = version("bittensor")
             result = subprocess.run(
@@ -46,10 +48,18 @@ class LocalMetadata:
             remote_commit_hash = remote_commit[:16]
 
         except Exception as e:
-            commit_hash = "unknown"
+            commit_hash = "exception unknown"
 
         return LocalMetadata(
             head=commit_hash,
             remote_head=remote_commit_hash,
             btversion=bittensor_version,
         )
+    
+
+    @staticmethod
+    def version_match() -> bool:
+        meta = LocalMetadata.local_metadata()
+        if not meta.head or not meta.remote_head:
+            raise ValueError("Could not get local or remote head")
+        return meta.head == meta.remote_head

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import BaseModel
+from template.utils.version import LocalMetadata
+
+
+def test_basic_meta_init_state_ok():
+    m = LocalMetadata.local_metadata()
+    assert m.head != "head error"
+    assert m.remote_head != "remote head error"
+    assert m.btversion != "metadata exception"
+    assert m.uid == 0
+    assert m.coldkey == ""
+    assert m.hotkey == ""
+    assert isinstance(m.head, str)
+
+    print(m.head)
+    print(m.remote_head)
+    print(m.btversion)
+
+
+def test_local_version_matches_head():
+    m = LocalMetadata.local_metadata()
+    
+    if(m.head != m.remote_head):
+        print("WARNING Versions do not match - ensure on main branch and updated")
+
+    assert m.head == m.remote_head
+
+
+def test_version_check_expected_ok():
+    m = LocalMetadata.local_metadata()
+    match_result = m.version_match()
+    if not match_result:
+        assert m.head != m.remote_head
+    else:
+        assert m.head == m.remote_head
+    


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling of local metadata and adding tests for the new functionality. The most important changes include updates to the `LocalMetadata` class and the addition of new tests to ensure the integrity of metadata extraction.

Improvements to `LocalMetadata` class:

* [`template/utils/version.py`](diffhunk://#diff-3e5c6dbfd6d48400fded557745f3c6e2203a291ea969c0816a9469f2197a5eecL24-R26): Updated the `local_metadata` method to handle exceptions more explicitly by setting default error messages for `commit_hash`, `remote_commit_hash`, and `bittensor_version`. Added a new static method `version_match` to check if the local and remote commit hashes match. [[1]](diffhunk://#diff-3e5c6dbfd6d48400fded557745f3c6e2203a291ea969c0816a9469f2197a5eecL24-R26) [[2]](diffhunk://#diff-3e5c6dbfd6d48400fded557745f3c6e2203a291ea969c0816a9469f2197a5eecL49-R65)

Addition of new tests:

* [`tests/test_meta.py`](diffhunk://#diff-ffb9385e1c544b8ac940677936baf9a4520028e3e74e7e02a6f62c1ae4a53d12R1-R37): Added new tests to verify the initial state of `LocalMetadata`, ensure the local version matches the head, and check the version match functionality. These tests include `test_basic_meta_init_state_ok`, `test_local_version_matches_head`, and `test_version_check_expected_ok`.